### PR TITLE
Remove duplicated text about routes in MTU block

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,8 +671,6 @@ Optionally defines the maximum transmission unit (MTU, aka packet/frame size) to
 
 The MTU is automatically determined from the endpoint addresses or the system default route, which is usually a sane choice.
 
-There are two special values: ‘off’ disables the creation of routes altogether, and ‘auto’ (the default) adds routes to the default table and enables special handling of default routes.
-
 https://git.zx2c4.com/WireGuard/about/src/tools/man/wg-quick.8
 
 **Examples**


### PR DESCRIPTION
There is a duplicated paragraph about routing in the MTU block