### PR TITLE
Expand on config file naming & placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ Overview of the general process:
 4. Create a `/etc/wireguard/wg0.conf` WireGuard config file on each client node
    - `[Interface]` Make sure to specify only a single IP for client peers that don't relay traffic `Address = 192.0.2.3/32`.
    - `[Peer]` Create a peer section for each public peer not behind a NAT, make sure to specify a CIDR range for the entire VPN subnet when defining the remote peer acting as the bounce server `AllowedIPs = 192.0.2.1/24`. Make sure to specify individual IPs for remote peers that don't relay traffic and only act as simple clients `AllowedIPs = 192.0.2.3/32`.
-5. Start WireGuard on the main relay server with `wg-quick up wg0`
-6. Start WireGuard on all the client peers with `wg-quick up wg0`
+5. Start WireGuard on the main relay server with `wg-quick up /etc/wireguard/wg0.conf`
+6. Start WireGuard on all the client peers with `wg-quick up /etc/wireguard/wg0.conf`
 7. Traffic is routed from peer to peer using most specific route first over the WireGuard interface, e.g. `ping 192.0.2.3` checks for a direct route to a peer with `AllowedIPs = 192.0.2.3/32` first, then falls back to a relay server that's accepting ips in the whole subnet
 
 ### Setup
@@ -440,8 +440,9 @@ wg pubkey < example.key > example.key.pub
 
 ```bash
 # first, create a configuration file at /etc/wireguard/wg0.conf
-wg-quick up wg0
-wg-quick down wg0
+wg-quick up /etc/wireguard/wg0.conf
+wg-quick down /etc/wireguard/wg0.conf
+# Note: you must specify the absolute path to wg0.conf, relative paths won't work
 ```
 
 ```bash
@@ -572,11 +573,8 @@ dig example.com A
 WireGuard config files are in INI syntax. The configuration is specified as an argument when running any `wg-quick` command, e.g.:
 
 ```bash
-# if the configuration file is at /etc/wireguard/wg0.conf
-wg-quick up wg0
-
-# if the configuration file is stored anywhere else, you must use an absolute path; relative paths won't work
-wq-quick up /tmp/wgtest.conf
+# you must use an absolute path; relative paths won't work
+wq-quick up /etc/wireguard/wg0.conf
 ```
 
 The file name must be in the format `${name of the new wireguard interface}.conf`. `wg-quick` looks for config files in `/etc/wireguard` by default, so it usually makes sense to place them there. Wireguard interface names are typically prefixed with `wg` and numbered starting at `0`, but you can use any name that matches the regex `^[a-zA-Z0-9_=+.-]{1,15}$`. A configuration file for the interface `wg0` would typically be found at `/etc/wireguard/wg0.conf`.

--- a/README.md
+++ b/README.md
@@ -381,14 +381,14 @@ Overview of the general process:
 
 1. Install `apt install wireguard` or `pkg/brew install wireguard-tools` on each node
 2. Generate public and private keys locally on each node `wg genkey`+`wg pubkey`
-3. Create a `wg0.conf` WireGuard config file on the main relay server
+3. Create a `/etc/wireguard/wg0.conf` WireGuard config file on the main relay server
     - `[Interface]` Make sure to specify a CIDR range for the entire VPN subnet when defining the address the server accepts routes for `Address = 192.0.2.1/24`
     - `[Peer]` Create a peer section for every client joining the VPN, using their corresponding remote public keys
-4. Create a `wg0.conf` on each client node
+4. Create a `/etc/wireguard/wg0.conf` WireGuard config file on each client node
    - `[Interface]` Make sure to specify only a single IP for client peers that don't relay traffic `Address = 192.0.2.3/32`.
    - `[Peer]` Create a peer section for each public peer not behind a NAT, make sure to specify a CIDR range for the entire VPN subnet when defining the remote peer acting as the bounce server `AllowedIPs = 192.0.2.1/24`. Make sure to specify individual IPs for remote peers that don't relay traffic and only act as simple clients `AllowedIPs = 192.0.2.3/32`.
-5. Start WireGuard on the main relay server with `wg-quick up /full/path/to/wg0.conf`
-6. Start WireGuard on all the client peers with `wg-quick up /full/path/to/wg0.conf`
+5. Start WireGuard on the main relay server with `wg-quick up wg0`
+6. Start WireGuard on all the client peers with `wg-quick up wg0`
 7. Traffic is routed from peer to peer using most specific route first over the WireGuard interface, e.g. `ping 192.0.2.3` checks for a direct route to a peer with `AllowedIPs = 192.0.2.3/32` first, then falls back to a relay server that's accepting ips in the whole subnet
 
 ### Setup
@@ -423,7 +423,7 @@ iptables -t nat -A POSTROUTING -s 192.0.2.0/24 -o eth0 -j MASQUERADE
 
 ### Config Creation
 ```bash
-nano wg0.conf  # can be placed anywhere, must be referred to using absolute path
+nano /etc/wireguard/wg0.conf
 ```
 
 ### Key Generation
@@ -439,9 +439,9 @@ wg pubkey < example.key > example.key.pub
 ### Start / Stop
 
 ```bash
-wg-quick up /full/path/to/wg0.conf
-wg-quick down /full/path/to/wg0.conf
-# Note: you must specify the absolute path to wg0.conf, relative paths won't work
+# first, create a configuration file at /etc/wireguard/wg0.conf
+wg-quick up wg0
+wg-quick down wg0
 ```
 
 ```bash
@@ -569,10 +569,17 @@ dig example.com A
 
 ### Overview
 
-WireGuard config is in INI syntax, defined in a file usually called `wg0.conf`.  It can be placed anywhere on the system, but is often placed in `/etc/wireguard/wg0.conf`.  
+WireGuard config files are in INI syntax. The configuration is specified as an argument when running any `wg-quick` command, e.g.:
 
-The config path is specified as an argument when running any `wg-quick` command, e.g:  
-`wg-quick up /etc/wireguard/wg0.conf` (always specify the full, absolute path)
+```bash
+# if the configuration file is at /etc/wireguard/wg0.conf
+wg-quick up wg0
+
+# if the configuration file is stored anywhere else, you must use an absolute path; relative paths won't work
+wq-quick up /tmp/wgtest.conf
+```
+
+The file name must be in the format `${name of the new wireguard interface}.conf`. `wg-quick` looks for config files in `/etc/wireguard` by default, so it usually makes sense to place them there. Wireguard interface names are typically prefixed with `wg` and numbered starting at `0`, but you can use any name that matches the regex `^[a-zA-Z0-9_=+.-]{1,15}$`. A configuration file for the interface `wg0` would typically be found at `/etc/wireguard/wg0.conf`.
 
 Config files can opt to use the limited set of `wg` config options, or the more extended `wg-quick` options, depending on what command is preferred to start WireGuard.  These docs recommend sticking to `wg-quick` as it provides a more powerful and user-friendly config experience.
 

--- a/README.md
+++ b/README.md
@@ -381,14 +381,14 @@ Overview of the general process:
 
 1. Install `apt install wireguard` or `pkg/brew install wireguard-tools` on each node
 2. Generate public and private keys locally on each node `wg genkey`+`wg pubkey`
-3. Create a `/etc/wireguard/wg0.conf` WireGuard config file on the main relay server
+3. Create a `wg0.conf` WireGuard config file on the main relay server
     - `[Interface]` Make sure to specify a CIDR range for the entire VPN subnet when defining the address the server accepts routes for `Address = 192.0.2.1/24`
     - `[Peer]` Create a peer section for every client joining the VPN, using their corresponding remote public keys
-4. Create a `/etc/wireguard/wg0.conf` WireGuard config file on each client node
+4. Create a `wg0.conf` on each client node
    - `[Interface]` Make sure to specify only a single IP for client peers that don't relay traffic `Address = 192.0.2.3/32`.
    - `[Peer]` Create a peer section for each public peer not behind a NAT, make sure to specify a CIDR range for the entire VPN subnet when defining the remote peer acting as the bounce server `AllowedIPs = 192.0.2.1/24`. Make sure to specify individual IPs for remote peers that don't relay traffic and only act as simple clients `AllowedIPs = 192.0.2.3/32`.
-5. Start WireGuard on the main relay server with `wg-quick up /etc/wireguard/wg0.conf`
-6. Start WireGuard on all the client peers with `wg-quick up /etc/wireguard/wg0.conf`
+5. Start WireGuard on the main relay server with `wg-quick up /full/path/to/wg0.conf`
+6. Start WireGuard on all the client peers with `wg-quick up /full/path/to/wg0.conf`
 7. Traffic is routed from peer to peer using most specific route first over the WireGuard interface, e.g. `ping 192.0.2.3` checks for a direct route to a peer with `AllowedIPs = 192.0.2.3/32` first, then falls back to a relay server that's accepting ips in the whole subnet
 
 ### Setup
@@ -439,9 +439,8 @@ wg pubkey < example.key > example.key.pub
 ### Start / Stop
 
 ```bash
-# first, create a configuration file at /etc/wireguard/wg0.conf
-wg-quick up /etc/wireguard/wg0.conf
-wg-quick down /etc/wireguard/wg0.conf
+wg-quick up /full/path/to/wg0.conf
+wg-quick down /full/path/to/wg0.conf
 # Note: you must specify the absolute path to wg0.conf, relative paths won't work
 ```
 
@@ -570,14 +569,12 @@ dig example.com A
 
 ### Overview
 
-WireGuard config files are in INI syntax. The configuration is specified as an argument when running any `wg-quick` command, e.g.:
+WireGuard config is in INI syntax, defined in a file usually called `wg0.conf`.  It can be placed anywhere on the system, but is often placed in `/etc/wireguard/wg0.conf`.  
 
-```bash
-# you must use an absolute path; relative paths won't work
-wq-quick up /etc/wireguard/wg0.conf
-```
+The config path is specified as an argument when running any `wg-quick` command, e.g:  
+`wg-quick up /etc/wireguard/wg0.conf` (always specify the full, absolute path)
 
-The file name must be in the format `${name of the new wireguard interface}.conf`. `wg-quick` looks for config files in `/etc/wireguard` by default, so it usually makes sense to place them there. Wireguard interface names are typically prefixed with `wg` and numbered starting at `0`, but you can use any name that matches the regex `^[a-zA-Z0-9_=+.-]{1,15}$`. A configuration file for the interface `wg0` would typically be found at `/etc/wireguard/wg0.conf`.
+The config file name must be in the format `${name of the new wireguard interface}.conf`. WireGuard interface names are typically prefixed with `wg` and numbered starting at `0`, but you can use any name that matches the regex `^[a-zA-Z0-9_=+.-]{1,15}$`.
 
 Config files can opt to use the limited set of `wg` config options, or the more extended `wg-quick` options, depending on what command is preferred to start WireGuard.  These docs recommend sticking to `wg-quick` as it provides a more powerful and user-friendly config experience.
 


### PR DESCRIPTION
Two main changes:
-  standardize on `/etc/wireguard` for config file storage
-  elaborate on config file naming rules and conventions

Using `/etc/wireguard` makes more sense because:
-  `wg-quick` looks there by default
-  using the convention helps maintainability
-  more concise syntax
-  simplifies the quick start guide