### PR TITLE
Add Yggdrasil network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ But you can write your own solutions for these problems using WireGuard under th
  - [TINC](https://www.tinc-vpn.org/): haven't tried it yet, but it doesn't work on iOS, worst case scenario I could live
  - [VPNCloud](https://github.com/dswd/vpncloud): similar properties to WireGuard, with more auto-mesh features
  - [cjdns](https://github.com/cjdelisle/cjdns): haven't tried it yet, should I?
- - [Yggdrasil network](https://yggdrasil-network.github.io/): It is lightweight, self-arranging, supported on multiple platforms and allows pretty much any IPv6-capable application to communicate securely with other Yggdrasil nodes.
  - [ZeroTier](https://www.zerotier.com): haven't tried it yet, should I
  - [MeshBird](https://github.com/meshbird/meshbird): "Cloud native" VPN/networking layer
+ - [Yggdrasil Network](https://yggdrasil-network.github.io/): Yggdrasil is a self-arranging IPv4/IPv6 mesh VPN (haven't tried it yet)
 
 ### VPN Setup Tools
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ But you can write your own solutions for these problems using WireGuard under th
  - [TINC](https://www.tinc-vpn.org/): haven't tried it yet, but it doesn't work on iOS, worst case scenario I could live
  - [VPNCloud](https://github.com/dswd/vpncloud): similar properties to WireGuard, with more auto-mesh features
  - [cjdns](https://github.com/cjdelisle/cjdns): haven't tried it yet, should I?
+ - [Yggdrasil network](https://yggdrasil-network.github.io/): It is lightweight, self-arranging, supported on multiple platforms and allows pretty much any IPv6-capable application to communicate securely with other Yggdrasil nodes.
  - [ZeroTier](https://www.zerotier.com): haven't tried it yet, should I
  - [MeshBird](https://github.com/meshbird/meshbird): "Cloud native" VPN/networking layer
 


### PR DESCRIPTION
More information here: https://yggdrasil-network.github.io/

> Yggdrasil is an early-stage implementation of a fully end-to-end encrypted IPv6 network. It is lightweight, self-arranging, supported on multiple platforms and allows pretty much any IPv6-capable application to communicate securely with other Yggdrasil nodes. Yggdrasil does not require you to have IPv6 Internet connectivity - it also works over IPv4.

Network size: about 500 nodes.
IRC: Freenode #yggdrasil (about 200 users) and #yggdrasil-community.

A Ygg node can look like this: https://ygg.tlbs.ai