### PR TITLE
Add dsnet to WireGuard Setup Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ These are some GUI and CLI tools that wrap WireGuard to assist with config, depl
  - https://github.com/complexorganizations/wireguard-manager
  - https://github.com/influxdata/wirey
  - https://github.com/apognu/wgctl
+ - https://github.com/naggie/dsnet/
 
 
 ### Config Shortcuts


### PR DESCRIPTION
dsnet is a simple command to manage a centralised wireguard VPN. Think wg-quick but quicker.


PR suggested on hacker news:
https://news.ycombinator.com/item?id=23299023

Thanks!