### PR TITLE
Add wgsd to NAT-to-NAT and related

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,7 @@ NAT-to-NAT connections from behind NATs with strict source-port randomization is
 
 - https://github.com/takutakahashi/wg-connect
 - https://git.zx2c4.com/wireguard-tools/tree/contrib/nat-hole-punching/
+- https://github.com/jwhited/wgsd
 
 ##### Dynamic IP addresses
 Many users report having to restart WireGuard whenever a dynamic IP changes, as it only resolves hostnames on startup. To force WireGuard to re-resolve dynamic DNS `Endpoint` hostnames more often, you may want to use a `PostUp` hook to restart WireGuard every few minutes or hours.
@@ -1005,6 +1006,7 @@ NAT-to-NAT connections are often more unstable and have other limitations, which
  - https://github.com/WireGuard/WireGuard/tree/master/contrib/examples/nat-hole-punching
  - https://staaldraad.github.io/2017/04/17/nat-to-nat-with-wireguard/
  - https://golb.hplar.ch/2019/01/expose-server-vpn.html
+ - https://www.jordanwhited.com/posts/wireguard-endpoint-discovery-nat-traversal/
 
 **Example**
 
@@ -1297,6 +1299,7 @@ For more details see the Further Reading: Docker section below.
 - https://github.com/apognu/wgctl
 - https://github.com/tailscale/tailscale
 - https://github.com/pivpn/pivpn
+- https://github.com/jwhited/wgsd
 
 ### Docker
 


### PR DESCRIPTION
wgsd is a CoreDNS plugin that serves WireGuard peer information via DNS-SD (RFC6763) semantics. This enables dynamic discovery of WireGuard Endpoint addressing (both IP address and port number) with the added benefit of NAT-to-NAT WireGuard connectivity where UDP hole punching is supported.