### PR TITLE
Missing proxy ARP value (1 – enabled, 0 – disabled) 

### DIFF
--- a/example-simple-server-to-server/server1/setup.sh
+++ b/example-simple-server-to-server/server1/setup.sh
@@ -7,8 +7,8 @@ apt install wireguard
 
 # to enable kernel relaying/forwarding ability on bounce servers
 echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
-echo "net.ipv4.conf.all.proxy_arp" >> /etc/sysctl.conf
-sudo sysctl -p /etc/sysctl.conf
+echo "net.ipv4.conf.all.proxy_arp = 1" >> /etc/sysctl.conf
+sysctl -p /etc/sysctl.conf
 
 # to add iptables forwarding rules on bounce servers
 iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT


### PR DESCRIPTION
- On all docs missing value on proxy ARP (1 – enabled, 0 – disabled).
- Line 11 'sudo ' not required as all script written for root user.