### PR TITLE
Fix incorrect IPv6 example syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ The examples in these docs primarily use IPv4, but WireGuard natively supports I
 
 ```ini
 [Interface]
-AllowedIps = 192.0.2.3/24, 2001:DB8::/64
+Address = 192.0.2.3/24, 2001:DB8::/64
 
 [Peer]
 ...


### PR DESCRIPTION
Fix Interface section to use Address= instead of AllowedIPs= in the IPv6 example section. https://github.com/pirate/wireguard-docs?tab=readme-ov-file#ipv6

Let me know if I need to further elaborate. Thanks for your time reviewing.