### PR TITLE
Fix internet browsing vpn example forward rule

### DIFF
--- a/example-internet-browsing-vpn/server/setup.sh
+++ b/example-internet-browsing-vpn/server/setup.sh
@@ -14,4 +14,5 @@ sysctl -p /etc/sysctl.conf
 iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -i wg0 -o wg0 -m conntrack --ctstate NEW -j ACCEPT
+iptables -A FORWARD -i wg0 -o eth0 -m conntrack --ctstate NEW -j ACCEPT
 iptables -t nat -A POSTROUTING -s 10.0.44.0/24 -o eth0 -j MASQUERADE


### PR DESCRIPTION
Hello,

I believe an `iptables` `FORWARD` rule is missing in `example-internet-browsing-vpn`. 

If the global `FORWARD` policy is `DROP`, I believe that we need to accept forwarding connections from VPN (`wg0`) to Ethernet interface (`eth0`).